### PR TITLE
exa fixes - config file and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,13 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Exa ###
+*chromedriver*
+*google-chrome-stable*
+*LATEST_RELEASE*
+driver/
+target/
+.idea/
+*.iml
+*.class

--- a/src/test/java/SeleniumTest.java
+++ b/src/test/java/SeleniumTest.java
@@ -18,7 +18,7 @@ public class SeleniumTest {
     @Before
     public void setUp() {
         // Set up ChromeDriver path
-        System.setProperty("webdriver.chrome.driver", "/driver/chromedriver");//linux_64
+        System.setProperty("webdriver.chrome.driver", "driver/chromedriver");//linux_64
 
         // Get file
         File file = new File("IfStatement.html");


### PR DESCRIPTION
Config file property chromeDriver is directory path relative to the project workspace. "-d driver" will create the driver directory in the workspace and download the file there. selenium path then is "driver/chromedriver" 

Included some new entries to gitignore to stop commits from pushing chromedriver and other extra files back to the repo.